### PR TITLE
Add gitbook block for embedding klipse with snippet configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ print [x + 1 for x in range(10)]
 &grave;&grave;&grave;
 </code></pre>
 
-
 # Ruby
 <pre><code>
 &grave;&grave;&grave;eval-ruby
@@ -63,7 +62,6 @@ print [x + 1 for x in range(10)]
 &grave;&grave;&grave;
 </code></pre>
 
-
 # PHP
 
 <pre><code>
@@ -73,4 +71,22 @@ var_dump($var);
 &grave;&grave;&grave;
 </code></pre>
 
+# Using options
 
+You can define snippet level configuration by using gitbook blocks instead of code fences. The first argument is always the language, followed by named arguments for all other configuration options. All option names are camelCased.
+
+## Clojure & ClojureScript
+
+```
+{% klipse "eval-clojure", loopMsec="1000" %}
+(rand)
+{% klipseend %}
+```
+
+## Javascript
+
+```
+{% klipse "eval-js", loopMsec="1000" %}
+new Date()
+{% klipseend %}
+```

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can define snippet level configuration by using gitbook blocks instead of co
 ```
 {% klipse "eval-clojure", loopMsec="1000" %}
 (rand)
-{% klipseend %}
+{% endklipse %}
 ```
 
 ## Javascript
@@ -88,5 +88,5 @@ You can define snippet level configuration by using gitbook blocks instead of co
 ```
 {% klipse "eval-js", loopMsec="1000" %}
 new Date()
-{% klipseend %}
+{% endklipse %}
 ```

--- a/index.js
+++ b/index.js
@@ -1,3 +1,7 @@
+var toCamelCase = function(s) {
+    return s.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase(); });
+}
+
 module.exports = {
     // Map of hooks
     hooks: {
@@ -36,7 +40,49 @@ module.exports = {
     },
 
     // Map of new blocks
-    blocks: {},
+    blocks: {
+        klipse: {
+            process: function(block) {
+                var lang = block.kwargs.lang || block.args[0];
+                var langClass = ' class="lang-' + lang + '"';
+
+                var hidden = block.kwargs.hidden ? ' class="hidden"' : '';
+                var pre = '<pre' + hidden + '>';
+
+                var opts = [
+                    // All snippets
+                    'eval-idle-msec',
+                    'loop-msec',
+                    'preamble',
+                    'gist-id',
+                    // Javascript and Clojure only
+                    'external-libs',
+                    // Javascript only
+                    'async-code',
+                    // Clojure only
+                    'static-fns',
+                    'print-length',
+                    'beautify-strings',
+                    'verbose',
+                    'max-eval-duration',
+                    'compile-display-guard'
+                ].reduce(function(a, c) {
+                    var camelCased = toCamelCase(c);
+                    if (block.kwargs.hasOwnProperty(camelCased)) {
+                        return a + ' data-' + c + '="' + block.kwargs[camelCased] + '"';
+                    }
+                    return a;
+                }, '');
+
+                var code = '<code'
+                    + langClass
+                    + opts
+                    + '>' + block.body + '</code>'
+
+                return pre + code + '</pre>';
+            }
+        }
+    },
 
     // Map of new filters
     filters: {}


### PR DESCRIPTION
I felt it would be a good idea to add a gitbook template block to this plugin so that klipse snippets can be configurable without directly using HTML. The existing code fencing will continue to work. This PR adds a klipse block that works something like this:

```
{% klipse "eval-js", loopMsec="1000" %}
new Date();
{% endklipse %}
```